### PR TITLE
Aggregating Publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ target_link_libraries(worker PRIVATE ThreadComms UtilTime::Time GTest::GTest GTe
 target_compile_features(worker PRIVATE cxx_std_17)
 
 #
+# Hack - pull all of the tests into a single executable.
+#
+# This works around a limitation of cpp-coveralls whereby it drops
+# the coverage of earlier runs for templated files.
+#
+add_executable(allTests test/worker.cpp test/pipe.cpp test/agg.cpp)
+target_link_libraries(allTests PRIVATE ThreadComms UtilTime::Time GTest::GTest GTest::Main)
+target_compile_features(allTests PRIVATE cxx_std_17)
+
+#
 # NOTE: Valgrind must be configured *before* testing is imported
 #
 set(MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --track-origins=yes --freelist-vol=2000000000 --error-exitcode=1 --track-fds=yes --num-callers=50 --fullpath-after= --trace-children=yes --leak-check=full" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(Boost REQUIRED)
 # Exported Library (libThreadComms)
 #
 add_library(ThreadComms STATIC
+    include/AggPipePub.h
+    include/AggPipePub.hpp
+    include/AggUpdate.h
     include/IPostable.h
     include/PipePublisher.h
     include/PipePublisher.hpp
@@ -24,6 +27,7 @@ add_library(ThreadComms STATIC
     include/WorkerThread.h
     src/WorkerThread.cpp
 )
+
 target_link_libraries(ThreadComms PUBLIC
     Threads::Threads
     Boost::boost
@@ -33,6 +37,9 @@ target_include_directories(ThreadComms PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 set_property(TARGET ThreadComms PROPERTY PUBLIC_HEADER
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub.h
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub.hpp
+    ${ThreadComms_SOURCE_DIR}/include/AggUpddate.h
     ${ThreadComms_SOURCE_DIR}/include/IPostable.h
     ${ThreadComms_SOURCE_DIR}/include/PipePublisher.h
     ${ThreadComms_SOURCE_DIR}/include/PipePublisher.hpp
@@ -43,7 +50,7 @@ set_property(TARGET ThreadComms PROPERTY PUBLIC_HEADER
 
 add_executable(publisherSpeed src/publisherSpeed.cpp src/dummy.cpp)
 target_link_libraries(publisherSpeed ThreadComms UtilTime::Time)
-target_compile_features(publisherSpeed PRIVATE cxx_std_14)
+target_compile_features(publisherSpeed PRIVATE cxx_std_17)
 
 #
 # Test Configuration
@@ -52,11 +59,15 @@ find_package(GTest REQUIRED)
 
 add_executable(pipe test/pipe.cpp)
 target_link_libraries(pipe ThreadComms GTest::GTest GTest::Main)
-target_compile_features(pipe PRIVATE cxx_std_14)
+target_compile_features(pipe PRIVATE cxx_std_17)
+
+add_executable(agg test/agg.cpp include/AggPipePub.h)
+target_link_libraries(agg ThreadComms GTest::GTest GTest::Main)
+target_compile_features(agg PRIVATE cxx_std_17)
 
 add_executable(worker test/worker.cpp)
 target_link_libraries(worker PRIVATE ThreadComms UtilTime::Time GTest::GTest GTest::Main)
-target_compile_features(worker PRIVATE cxx_std_14)
+target_compile_features(worker PRIVATE cxx_std_17)
 
 #
 # NOTE: Valgrind must be configured *before* testing is imported
@@ -67,6 +78,7 @@ include (CTest)
 
 enable_testing()
 add_test(pipe pipe)
+add_test(agg agg)
 add_test(worker worker)
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,13 @@ set(MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --track-origins=yes --fr
 find_program(MEMORYCHECK_COMMAND valgrind )
 include (CTest)
 
+# Declare individual test binaries in preference to allTests, for greater
+# granularity in the event of crash / fault to track down.
 enable_testing()
 add_test(pipe pipe)
 add_test(agg agg)
 add_test(worker worker)
+
 
 #
 # Installation instructions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Boost REQUIRED)
 add_library(ThreadComms STATIC
     include/AggPipePub.h
     include/AggPipePub.hpp
+    include/AggPipePub_MessageAdaption.h
     include/AggUpdate.h
     include/IPostable.h
     include/PipePublisher.h
@@ -39,6 +40,7 @@ target_include_directories(ThreadComms PUBLIC
 set_property(TARGET ThreadComms PROPERTY PUBLIC_HEADER
     ${ThreadComms_SOURCE_DIR}/include/AggPipePub.h
     ${ThreadComms_SOURCE_DIR}/include/AggPipePub.hpp
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub_MessageAdaption.h
     ${ThreadComms_SOURCE_DIR}/include/AggUpddate.h
     ${ThreadComms_SOURCE_DIR}/include/IPostable.h
     ${ThreadComms_SOURCE_DIR}/include/PipePublisher.h
@@ -62,7 +64,7 @@ target_link_libraries(pipe ThreadComms GTest::GTest GTest::Main)
 target_compile_features(pipe PRIVATE cxx_std_17)
 
 add_executable(agg test/agg.cpp include/AggPipePub.h)
-target_link_libraries(agg ThreadComms GTest::GTest GTest::Main)
+target_link_libraries(agg ThreadComms UtilTime::Time GTest::GTest GTest::Main)
 target_compile_features(agg PRIVATE cxx_std_17)
 
 add_executable(worker test/worker.cpp)

--- a/include/AggPipePub.h
+++ b/include/AggPipePub.h
@@ -8,29 +8,117 @@
 #include <AggUpdate.h>
 #include <map>
 
+#include <AggPipePub_MessageAdaption.h>
+
+
+// Aggregated Data Update Publisher
+//
+// This is a special variant of the PipePublisher, designed to throttle
+// update notices, protecting client threads that have perform expensive
+// operations on each update.
+//
+// The primary use case is model a remote data-set, over a potentially
+// flakey connection. The interface wrapping an AggPipePub may recover
+// and only notify the
+//
+//  Remote                  Remote Interface            Client
+//                        (Adapting AggPipePub)
+//  SYSTEM START
+//     |              <--Subscribe-- |                          |
+//     | -- Initial Data {0,1,2} --> |                          |
+//     |                             |  --    NEW {0} -->       |
+//     |                             |  --    NEW {1} -->       |
+//     |                             |  --    NEW {2} -->       |
+//     | -- Update {1} -->           |                          |
+//     |                             |  -- UPDATE {1} -->       |
+//     | -- Update {2} -->           |                          |
+//                                  /* {2} unchanged - No update  */
+//     | -- Update {3} -->           |                          |
+//     |                             |  --    NEW {3} -->       |
+//  Remote disconnect - wait for reconnect
+//  ...
+//  Remote reconnected - determine missed updates
+//     |              <--Subscribe-- |                          |
+//     |-- Initial Data {0,1,3,4}--> |                          |
+//                                  /* {0} unchanged - No update  */
+//     |                             |  -- UPDATE {1} -->       |
+//     |                             |  -- DELETE {2} -->       |
+//                                  /* {3} unchanged - No update  */
+//     |                             |  --    NEW {4} -->       |
+//
+// NOTE: Unlike the underlying PipePublisher, the AggPub publishes a
+//       shared_ptr to the Message, rather than performing a full copy
+//       to each thread.
 template <class Message>
 class AggPipePub {
 public:
-    using MsgRef = std::shared_ptr<const Message>;
-    using IdType = typename Message::AggIdType;
-    constexpr const IdType& GetId(const Message& m) {
-        return m.GetAggId();
-    }
-    constexpr bool IsUpdated(const Message& orig, const Message& n) {
-        return !orig.IsAggEqual(n);
-    }
-    void Update(MsgRef msg);
+// PUBLIC TYPE DEFINITIONS
 
+    // Shared Reference to the Message will be published to each subscriber
+    // thread.
+    using MsgRef = std::shared_ptr<const Message>;
+
+    // The AggUpdate wraps a MsgRef with an update type, so clients know
+    // whether the message is a NEW insert for this id, or an UPDATE to
+    // an already published
     using Upd = AggUpdate<Message>;
+
+    // Clients subscribe using a standard PipeSubscriber object.
     using Client = PipeSubscriber<Upd>;
     using ClientRef = std::shared_ptr<Client>;
-    /**
-     * Create a new subscription to the update publisher.
-     */
+
+// PUBLIC INTERFACE
+    // Nothing special required for construction.
+    AggPipePub() = default;
+
+    // Push a new Message into the data set. Existing clients will
+    // get a NEW if they this is the first time the id has been seen,
+    // and an UPDATE otherwise.
+    //
+    // Clients who subscribe after the message has been processed will
+    // see the update as a NEW when they get their initial data (the
+    // latest message per id)
+    //
+    // NOTE: Due to the use of a PipePublisher, only *ONE THREAD* is allowed
+    //       to publish (ever). Although not strictly required, convention is
+    //       that it is the same thread that constructed the AggPipePub.
+    void Update(MsgRef msg);
+
+    // Register a new client.
+    //
+    // This is a standard PipeSubscriber object, receiving update publication
+    // when data changes (see comment against the Update method).
+    //
+    // The client will be pre-loaded with the existing data set - a NEW update
+    // for each unique idea that has already been seen by the publisher.
+    //
+    // NOTE: The publisher is locked during construction, and no further updates
+    //       may be posted until the client has been successfully initialised.
+    //
+    // NOTE: See note on threading restrctions documented on PipeSubscriber.
     std::shared_ptr<PipeSubscriber<Upd>> NewClient(const size_t& maxQueueSize);
 
 private:
-    std::map<IdType, MsgRef> data;
+    using Adapter = AggPipePub_Adaption::MessageAdapter<Message>;
+    using IdType = typename Adapter::GetAggIdValueType;
+
+    constexpr const IdType GetId(const Message& m) {
+        return Adapter::Get(m);
+    }
+
+    constexpr bool IsUpdated(const Message& orig, const Message& n) {
+        return !Adapter::IsEqual(orig, n);
+    }
+
+    class LockedData {
+    public:
+        using DataType = std::map<IdType, MsgRef>;
+        void WithData(const std::function<void (DataType& data)>&);
+    private:
+        std::mutex   dataMutex;
+        DataType data;
+    };
+    LockedData dataStore;
     Upd ManufactureUpdate(MsgRef msg);
     Upd ManufactureNewUpdate(MsgRef msg);
     PipePublisher<Upd> pub_;

--- a/include/AggPipePub.h
+++ b/include/AggPipePub.h
@@ -1,0 +1,29 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#ifndef THREADCOMMS_AGGPIPEPUB_H
+#define THREADCOMMS_AGGPIPEPUB_H
+
+#include <PipePublisher.h>
+#include <AggUpdate.h>
+
+template <class Message>
+class AggPipePub {
+public:
+    using MsgRef = std::shared_ptr<Message>;
+    void Update(MsgRef msg);
+
+    using Upd = AggUpdate<Message>;
+    /**
+     * Create a new subscription to the update publisher.
+     */
+    template <class Client = PipeSubscriber<Upd>, class... Args>
+    std::shared_ptr<Client> NewClient(Args... args);
+
+private:
+    Upd ManufactureUpdate(MsgRef msg);
+    PipePublisher<Upd> pub_;
+};
+
+#include <AggPipePub.hpp>
+#endif //THREADCOMMS_AGGPIPEPUB_H

--- a/include/AggPipePub.h
+++ b/include/AggPipePub.h
@@ -6,11 +6,19 @@
 
 #include <PipePublisher.h>
 #include <AggUpdate.h>
+#include <map>
 
 template <class Message>
 class AggPipePub {
 public:
-    using MsgRef = std::shared_ptr<Message>;
+    using MsgRef = std::shared_ptr<const Message>;
+    using IdType = typename Message::AggIdType;
+    constexpr const IdType& GetId(const Message& m) {
+        return m.GetAggId();
+    }
+    constexpr bool IsUpdated(const Message& orig, const Message& n) {
+        return !orig.IsAggEqual(n);
+    }
     void Update(MsgRef msg);
 
     using Upd = AggUpdate<Message>;
@@ -21,6 +29,7 @@ public:
     std::shared_ptr<Client> NewClient(Args... args);
 
 private:
+    std::map<IdType, MsgRef> data;
     Upd ManufactureUpdate(MsgRef msg);
     PipePublisher<Upd> pub_;
 };

--- a/include/AggPipePub.h
+++ b/include/AggPipePub.h
@@ -22,15 +22,17 @@ public:
     void Update(MsgRef msg);
 
     using Upd = AggUpdate<Message>;
+    using Client = PipeSubscriber<Upd>;
+    using ClientRef = std::shared_ptr<Client>;
     /**
      * Create a new subscription to the update publisher.
      */
-    template <class Client = PipeSubscriber<Upd>, class... Args>
-    std::shared_ptr<Client> NewClient(Args... args);
+    std::shared_ptr<PipeSubscriber<Upd>> NewClient(const size_t& maxQueueSize);
 
 private:
     std::map<IdType, MsgRef> data;
     Upd ManufactureUpdate(MsgRef msg);
+    Upd ManufactureNewUpdate(MsgRef msg);
     PipePublisher<Upd> pub_;
 };
 

--- a/include/AggPipePub.hpp
+++ b/include/AggPipePub.hpp
@@ -1,0 +1,24 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#ifndef THREADCOMMS_AGGPIPEPUB_HPP
+#define THREADCOMMS_AGGPIPEPUB_HPP
+#include <AggPipePub.h>
+
+template<class Message>
+template<class Client, class... Args>
+std::shared_ptr<Client> AggPipePub<Message>::NewClient(Args... args) {
+    return pub_.template NewClient<Client>(args...);
+}
+
+template<class Message>
+void AggPipePub<Message>::Update(std::shared_ptr<Message> m) {
+    pub_.Publish(ManufactureUpdate(std::move(m)));
+}
+
+template<class Message>
+typename AggPipePub<Message>::Upd AggPipePub<Message>::ManufactureUpdate(AggPipePub::MsgRef m) {
+    return Upd{std::move(m)};
+}
+
+#endif //THREADCOMMS_AGGPIPEPUB_HPP

--- a/include/AggPipePub.hpp
+++ b/include/AggPipePub.hpp
@@ -12,13 +12,29 @@ std::shared_ptr<Client> AggPipePub<Message>::NewClient(Args... args) {
 }
 
 template<class Message>
-void AggPipePub<Message>::Update(std::shared_ptr<Message> m) {
-    pub_.Publish(ManufactureUpdate(std::move(m)));
+void AggPipePub<Message>::Update(MsgRef m) {
+    auto upd = ManufactureUpdate(std::move(m));
+    if (upd.updateType != AggUpdateType::NONE) {
+        pub_.Publish(std::move(upd));
+    }
 }
 
 template<class Message>
 typename AggPipePub<Message>::Upd AggPipePub<Message>::ManufactureUpdate(AggPipePub::MsgRef m) {
-    return Upd{std::move(m)};
+    AggUpdateType updType = AggUpdateType::NEW;
+
+    auto id = GetId(*m);
+    auto it = data.find(id);
+    if (it == data.end()) {
+        data[id] =  m;
+    } else if (IsUpdated(*it->second, *m)) {
+        data.erase(it);
+        updType = AggUpdateType::UPDATE;
+    } else {
+        updType = AggUpdateType::NONE;
+    }
+
+    return Upd{std::move(m), updType};
 }
 
 #endif //THREADCOMMS_AGGPIPEPUB_HPP

--- a/include/AggPipePub.hpp
+++ b/include/AggPipePub.hpp
@@ -5,9 +5,10 @@
 #define THREADCOMMS_AGGPIPEPUB_HPP
 #include <AggPipePub.h>
 
-template<class Message>
-typename AggPipePub<Message>::ClientRef
-    AggPipePub<Message>::NewClient(const size_t& max)
+template<class Message,
+         AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message, updateMode>::ClientRef
+    AggPipePub<Message,updateMode>::NewClient(const size_t& max)
 {
     std::vector<Upd> initialData;
     dataStore.WithData([&] (auto& data) -> void {
@@ -20,16 +21,20 @@ typename AggPipePub<Message>::ClientRef
     return pub_.template NewClient<Client>(max, std::move(initialData));
 }
 
-template<class Message>
-void AggPipePub<Message>::Update(MsgRef m) {
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+void AggPipePub<Message,updateMode>::Update(MsgRef m) {
     auto upd = ManufactureUpdate(std::move(m));
     if (upd.updateType != AggUpdateType::NONE) {
         pub_.Publish(std::move(upd));
     }
 }
 
-template<class Message>
-typename AggPipePub<Message>::Upd AggPipePub<Message>::ManufactureUpdate(AggPipePub::MsgRef m) {
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message, updateMode>::Upd
+    AggPipePub<Message,updateMode>::ManufactureUpdate(AggPipePub::MsgRef m)
+{
     AggUpdateType updType = AggUpdateType::NEW;
     auto id = GetId(*m);
 
@@ -49,15 +54,17 @@ typename AggPipePub<Message>::Upd AggPipePub<Message>::ManufactureUpdate(AggPipe
     return Upd{std::move(m), updType};
 }
 
-template<class Message>
-typename AggPipePub<Message>::Upd
-    AggPipePub<Message>::ManufactureNewUpdate(AggPipePub::MsgRef msg)
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message,updateMode>::Upd
+    AggPipePub<Message,updateMode>::ManufactureNewUpdate(AggPipePub::MsgRef msg)
 {
     return AggPipePub::Upd{msg, AggUpdateType::NEW};
 }
 
-template<class Message>
-void AggPipePub<Message>::LockedData::WithData(
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+void AggPipePub<Message,updateMode>::LockedData::WithData(
         const std::function<void(DataType &data)>& task)
 {
     std::unique_lock<std::mutex> lock(dataMutex);

--- a/include/AggPipePub_MessageAdaption.h
+++ b/include/AggPipePub_MessageAdaption.h
@@ -1,0 +1,135 @@
+//
+// Created by lukeh on 13/10/2019.
+//
+
+#ifndef THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H
+#define THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H
+
+namespace AggPipePub_Adaption {
+
+    /*****************************************
+     *    Does Message have a GetAggId()?
+     *****************************************/
+    template<class Message, bool result = std::is_member_function_pointer<decltype(&Message::GetAggId)>::value>
+    constexpr bool HasGetAggId(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasGetAggId(...) { return false; }
+
+    /*****************************************
+     *    Does Message have a id member?
+     *****************************************/
+    template<class Message, bool result = std::is_member_object_pointer<decltype(&Message::id)>::value>
+    constexpr bool HasId(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasId(...) { return false; }
+
+    /*****************************************************
+     *    Does the Message provide an IsAggEqual method?
+     *****************************************************/
+    template<class Message, bool result = std::is_member_function_pointer<decltype(&Message::IsAggEqual)>::value>
+    constexpr bool HasAggEqual(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasAggEqual(...) { return false; }
+
+    /******************************************************
+     *    Provide ID Access to a Message that has a valid
+     *    GetAggId method.
+     *
+     *    NOTE: We still be a valid object if it doesn't
+     *          to ensure both types of enable_if are
+     *          valid - HOWEVER, we don't require working
+     *          getters / types in that scenario
+     ******************************************************/
+    template<class Message, bool HasGetter>
+    struct GetIdAdp {
+        using GetAggIdResultType =
+        typename std::conditional<
+                HasGetter,
+                decltype(((Message*)(nullptr))->GetAggId()),
+                nullptr_t>::type;
+        using GetAggIdValueType =
+                typename std::remove_reference<GetAggIdResultType>::type;
+
+        using EnableIf_HasGetAggId =
+            typename std::enable_if<HasGetter, GetAggIdValueType>::type;
+
+        static constexpr EnableIf_HasGetAggId Get(const Message& m) {
+            return m.GetAggId();
+        }
+    };
+
+    /******************************************************
+     *    Provide ID Access to a Message that has a valid
+     *    id member variable
+     *
+     *    NOTE: We still be a valid object if it doesn't
+     *          to ensure both types of enable_if are
+     *          valid - HOWEVER, we don't require working
+     *          getters / types in that scenario
+     ******************************************************/
+    template<class Message, bool HasId>
+    struct IdAdp {
+        using GetAggIdResultType =
+        typename std::conditional<
+                HasId,
+                decltype(((Message*)(nullptr))->id),
+                nullptr_t>::type;
+        using GetAggIdValueType  = typename std::remove_reference<GetAggIdResultType>::type;
+
+        using EnableIf_HasId =
+        typename std::enable_if<HasId, GetAggIdValueType>::type;
+
+        static constexpr EnableIf_HasId Get(const Message& m) {
+            return m.id;
+        }
+    };
+
+    /******************************************************
+     *  Adapt the message type to provide access to the Id
+     *  field.
+     ******************************************************/
+    template<class Message>
+    struct MessageAdapter {
+        static constexpr bool hasGetAggId = HasGetAggId<Message>(0);
+        static constexpr bool hasId = HasId<Message>(0);
+        static constexpr bool hasAggEq = HasAggEqual<Message>(0);
+
+        // Ensure the message as at least one way of accessing the id type
+        static_assert(hasGetAggId || hasId,
+                       "Message object has no viable Id Type!"
+                       " Object must provide one of :\n"
+                       "   struct Message { \n"
+                       "        <id type> id;\n"
+                       "        <id type> GetAggId() const;"
+                       "   };");
+
+
+
+        using GetAdapter =
+            typename std::conditional<
+                         hasGetAggId,
+                         GetIdAdp<Message, hasGetAggId>,
+                         IdAdp<Message, hasId>>::type;
+
+        using GetAggIdValueType  = typename GetAdapter::GetAggIdValueType;
+
+        static constexpr GetAggIdValueType Get(const Message& m) {
+            return GetAdapter::Get(m);
+        }
+
+        using EnableIf_HasAggEq =
+           typename std::enable_if<hasAggEq, bool>::type;
+
+        static constexpr EnableIf_HasAggEq IsEqual(
+                const Message& orig, const Message& upd)
+        {
+            return orig.IsAggEqual(upd);
+        }
+    };
+}
+
+
+#endif //THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H

--- a/include/AggUpdate.h
+++ b/include/AggUpdate.h
@@ -6,9 +6,31 @@
 #define THREADCOMMS_AGGUPDATE_H
 #include <memory>
 
+enum class AggUpdateType: char {
+    NEW ='N',
+    UPDATE ='U',
+    NONE ='O',
+};
+
+std::ostream& operator<<(std::ostream& os, const AggUpdateType& up) {
+    switch (up) {
+        case AggUpdateType::NEW:
+            os << "AggUpdateType::NEW";
+            break;
+        case AggUpdateType::UPDATE:
+            os << "AggUpdateType::UPDATE";
+            break;
+        default:
+            os << "AggUpdateType::UNKNOWN";
+            break;
+    }
+    return os;
+}
+
 template<class T>
 struct AggUpdate {
-    std::shared_ptr<T> data;
+    std::shared_ptr<const T> data;
+    AggUpdateType            updateType;
 };
 
 #endif //THREADCOMMS_AGGUPDATE_H

--- a/include/AggUpdate.h
+++ b/include/AggUpdate.h
@@ -1,0 +1,14 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+
+#ifndef THREADCOMMS_AGGUPDATE_H
+#define THREADCOMMS_AGGUPDATE_H
+#include <memory>
+
+template<class T>
+struct AggUpdate {
+    std::shared_ptr<T> data;
+};
+
+#endif //THREADCOMMS_AGGUPDATE_H

--- a/include/PipePublisher.h
+++ b/include/PipePublisher.h
@@ -43,7 +43,7 @@ public:
      * @param  maxSize  Maximum number of unread messages
      */
     template <class Client = PipeSubscriber<Message>, class... Args>
-    std::shared_ptr<Client> NewClient(Args... args);
+    std::shared_ptr<Client> NewClient(Args&&... args);
 
     void InstallClient(std::shared_ptr<IPipeConsumer<Message>> client);
 

--- a/include/PipePublisher.hpp
+++ b/include/PipePublisher.hpp
@@ -93,8 +93,8 @@ void PipePublisher<Message>::Publish(const Message& msg) {
 
 template <class Message>
 template <class Client, class... Args>
-std::shared_ptr<Client> PipePublisher<Message>::NewClient(Args... args) {
-    std::shared_ptr<Client> client (new Client(this, args...));
+std::shared_ptr<Client> PipePublisher<Message>::NewClient(Args&&... args) {
+    std::shared_ptr<Client> client (new Client(this, std::forward<Args>(args)...));
     InstallClient(client);
     return client;
 

--- a/include/PipeSubscriber.h
+++ b/include/PipeSubscriber.h
@@ -219,7 +219,8 @@ protected:
      */
     PipeSubscriber(
         PipePublisher<Message>* parent,
-        size_t maxSize);
+        size_t maxSize,
+        std::vector<Message> initData = {});
 
      struct PushToFullQueueException {
          Message msg;

--- a/include/PipeSubscriber.hpp
+++ b/include/PipeSubscriber.hpp
@@ -48,7 +48,8 @@ bool IPipeConsumer<Message>::ChangeState(STATE& current, STATE to) {
 template <class Message>
 PipeSubscriber<Message>::PipeSubscriber(
     PipePublisher<Message>* _parent,
-    size_t maxSize)
+    size_t maxSize,
+    std::vector<Message> initialData)
         : notifyState(DISABLED),
           onNotify(nullptr),
           targetToNotify(nullptr),
@@ -58,6 +59,9 @@ PipeSubscriber<Message>::PipeSubscriber(
           messages(maxSize)
 {
     forwardMessage = false;
+    for (const auto& m: initialData ) {
+        PushMessage(m);
+    }
 }
 
 template <class Message>

--- a/test/agg.cpp
+++ b/test/agg.cpp
@@ -347,9 +347,9 @@ TEST(TAggPuplisherThreads,LastSubFastPubRace) {
 
     IdPubRef pub = std::make_shared<IdPub>();
     IdClientRef client;
+    std::atomic_bool clientDone = false;
 
     WorkerThread pubThread, clientThread;
-    std::atomic_bool clientDone = false;
 
     pubThread.Start();
     pubThread.PostTask([&] () -> void {

--- a/test/agg.cpp
+++ b/test/agg.cpp
@@ -351,12 +351,20 @@ TEST(TAggPuplisherThreads,LastSubFastPubRace) {
 
     WorkerThread pubThread, clientThread;
 
+    auto loadData =  [&] () -> void {
+        for (size_t i = 0; i < 10; ++i) {
+            pub->Update(std::make_shared<IdStamp>(i));
+        }
+    };
+
     pubThread.Start();
+    pubThread.DoTask([&] () -> void {
+            loadData();
+    });
+
     pubThread.PostTask([&] () -> void {
         while (!clientDone) {
-            for (size_t i = 0; i < 10; ++i) {
-                pub->Update(std::make_shared<IdStamp>(i));
-            }
+            loadData();
         }
     });
 

--- a/test/agg.cpp
+++ b/test/agg.cpp
@@ -1,0 +1,87 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#include <PipePublisher.h>
+#include <gtest/gtest.h>
+#include <AggPipePub.h>
+#include <util_time.h>
+
+using namespace std;
+using namespace nstimestamp;
+
+struct Msg {
+    explicit Msg (std::string m): message(std::move(m)) {}
+
+    std::string   message;
+};
+using Msgs = std::vector<Msg>;
+
+using MsgAgg = AggPipePub<Msg>;
+using Upds = std::vector<MsgAgg::Upd>;
+
+struct ExpUpd {
+    Msg m;
+};
+using ExpUpds = std::vector<ExpUpd>;
+
+using ClientRef = std::shared_ptr<PipeSubscriber<MsgAgg::Upd>>;
+
+void MessagesMatch(ExpUpds& exp, Upds& got)
+{
+    ASSERT_EQ(exp.size(), got.size());
+
+    for (size_t i = 0; i < exp.size(); ++i) {
+        Msg& msg = exp[i].m;
+        Msg& recvd = *got[i].data;
+
+        ASSERT_EQ(msg.message, recvd.message);
+    }
+}
+
+void Publish(MsgAgg& pub, const Msg& m) {
+    auto cpy = std::make_shared<Msg>(m);
+    pub.Update(std::move(cpy));
+}
+void Publish(MsgAgg& pub, const Msgs& msgs) {
+    for (const Msg& m: msgs) {
+        Publish(pub, m);
+    }
+}
+
+void GetMessages(const size_t toGet, ClientRef& cli, Upds& dest) {
+    MsgAgg::Upd upd;
+    for (size_t i = 0; i < toGet; ++i) {
+        ASSERT_TRUE(cli->GetNextMessage(upd));
+        dest.push_back(upd);
+    }
+}
+
+TEST(TAggPuplisher,NewItems) {
+    MsgAgg pub;
+    ClientRef client = pub.NewClient(1024);
+
+    Msgs sent {
+        Msg{"Hello World!"}
+    };
+    Publish(pub, sent);
+
+    ExpUpds exp {
+        {Msg{"Hello World!"}}
+    };
+
+    Upds got;
+    ASSERT_NO_FATAL_FAILURE(GetMessages(1, client, got));
+    ASSERT_NO_FATAL_FAILURE(MessagesMatch(exp, got));
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/pipe.cpp
+++ b/test/pipe.cpp
@@ -82,8 +82,8 @@ TEST(TPipeSubscriber,Notify) {
 }
 
 TEST(TPipeSubscriber,WaitForMessage) {
-    WorkerThread pushThread;
     PipePublisher<Msg> publisher;
+    WorkerThread pushThread;
     std::shared_ptr<PipeSubscriber<Msg>> client(publisher.NewClient(1024));
     std::vector<Msg> toSend = {
         {"Message 1"},

--- a/test/pipe.cpp
+++ b/test/pipe.cpp
@@ -4,20 +4,22 @@
 
 using namespace std;
 
-struct Msg {
-    std::string   message;
-};
+namespace {
+    struct Msg {
+        std::string   message;
+    };
 
-void MessagesMatch(std::vector<Msg>& sent,
-                   std::vector<Msg>& got)
-{
-    ASSERT_EQ(sent.size(), got.size());
+    void MessagesMatch(std::vector<Msg>& sent,
+                       std::vector<Msg>& got)
+    {
+        ASSERT_EQ(sent.size(), got.size());
 
-    for (size_t i = 0; i < sent.size(); ++i) {
-        Msg& msg = sent[i];
-        Msg& recvd = got[i];
+        for (size_t i = 0; i < sent.size(); ++i) {
+            Msg& msg = sent[i];
+            Msg& recvd = got[i];
 
-        ASSERT_EQ(msg.message, recvd.message);
+            ASSERT_EQ(msg.message, recvd.message);
+        }
     }
 }
 

--- a/test/pipe.cpp
+++ b/test/pipe.cpp
@@ -287,6 +287,26 @@ TEST(TPipeSubscriber,ForEachData) {
     ASSERT_NO_FATAL_FAILURE(MessagesMatch(toSend,got));
 }
 
+TEST(TPipeSubscriber,InitialData) {
+    PipePublisher<Msg> publisher;
+    std::vector<Msg> toSend = {
+            {"Message 1"},
+            {"Mesasge 2"},
+            {"Hello World!"}
+    };
+    auto sent = toSend;
+    std::shared_ptr<PipeSubscriber<Msg>> client(publisher.NewClient(1024, std::move(toSend)));
+
+    std::vector<Msg> got;
+    auto f = [&] (const Msg& newMsg) -> void {
+        got.push_back(newMsg);
+    };
+
+    client->OnNewMessage(f);
+
+    ASSERT_NO_FATAL_FAILURE(MessagesMatch(sent,got));
+}
+
 TEST(TPipeSubscriber,BatchForEachData) {
     PipePublisher<Msg> publisher;
     std::shared_ptr<PipeSubscriber<Msg>> client(publisher.NewClient(1024));


### PR DESCRIPTION
This is a special variant of the PipePublisher, designed to throttle update
notices, protecting client threads that have to perform expensive operations on
each update.

The primary use case is model a remote data-set, over a potentially flakey
connection. The interface wrapping an AggPipePub may recover and only notify
the client threads if something has actually changed. When used in a
Microservices environment this allows components to be abstracted away from 
recovery (although only those components for which is safe to continue with
stale data).

```
 Remote                  Remote Interface            Client
                       (Adapting AggPipePub)
 SYSTEM START
    |              <--Subscribe-- |                          |
    | -- Initial Data {0,1,2} --> |                          |
    |                             |  --    NEW {0} -->       |
    |                             |  --    NEW {1} -->       |
    |                             |  --    NEW {2} -->       |
    | -- Update {1} -->           |                          |
    |                             |  -- UPDATE {1} -->       |
    | -- Update {2} -->           |                          |
                                 /* {2} unchanged - No update  */
    | -- Update {3} -->           |                          |
    |                             |  --    NEW {3} -->       |
 Remote disconnect - wait for reconnect
 ...
 Remote reconnected - determine missed updates
    |              <--Subscribe-- |                          |
    |-- Initial Data {0,1,3,4}--> |                          |
                                 /* {0} unchanged - No update  */
    |                             |  -- UPDATE {1} -->       |
    |                             |  -- DELETE {2} -->       |
                                 /* {3} unchanged - No update  */
    |                             |  --    NEW {4} -->       |
```