### PR TITLE
Aggregating pub (rebase)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ addons:
     packages:
       - cmake
       - cmake-data
-      - g++-8
+      - g++-9
       - libboost-all-dev
       - valgrind
+      - libperlio-gzip-perl
+      - libjson-perl
 
 
 before_install:
-  - export CXX="g++-8"
-  - export CC="gcc-8"
-  - g++-8 --version
+  - export CXX="g++-9"
+  - export CC="gcc-9"
+  - g++-9 --version
 
 install:
   - ./buildDeps.sh
@@ -29,4 +31,5 @@ script:
   - make test
   - ctest -T Memcheck
   - cd ..
-  - COVERALLS_FLAGS="-e src/publisherSpeed.cpp -e src/dummy.cpp" ./deps/CMakeUtils/travis/doCoverage.sh
+  - GCOV="gcov-9" LCOV_FILTERS="$PWD/src/publisherSpeed.cpp $PWD/src/dummy.cpp" ./deps/CMakeUtils/travis/doCoverage.sh
+  - find . -name "*PipeSubscriber*hpp.gcov" | xargs cat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ add_executable(pipe test/pipe.cpp)
 target_link_libraries(pipe ThreadComms GTest::GTest GTest::Main)
 target_compile_features(pipe PRIVATE cxx_std_17)
 
+add_executable(pipe_state_model test/pipe_state_model.cpp)
+target_link_libraries(pipe_state_model ThreadComms GTest::GTest GTest::Main)
+target_compile_features(pipe_state_model PRIVATE cxx_std_17)
+
 add_executable(agg test/agg.cpp include/AggPipePub.h)
 target_link_libraries(agg ThreadComms UtilTime::Time GTest::GTest GTest::Main)
 target_compile_features(agg PRIVATE cxx_std_17)
@@ -80,6 +84,7 @@ include (CTest)
 
 enable_testing()
 add_test(pipe pipe)
+add_test(pipe_state_model pipe_state_model)
 add_test(agg agg)
 add_test(worker worker)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(Boost REQUIRED)
 # Exported Library (libThreadComms)
 #
 add_library(ThreadComms STATIC
+    include/AggPipePub.h
+    include/AggPipePub.hpp
+    include/AggPipePub_MessageAdaption.h
+    include/AggUpdate.h
     include/IPostable.h
     include/PipePublisher.h
     include/PipePublisher.hpp
@@ -24,6 +28,7 @@ add_library(ThreadComms STATIC
     include/WorkerThread.h
     src/WorkerThread.cpp
 )
+
 target_link_libraries(ThreadComms PUBLIC
     Threads::Threads
     Boost::boost
@@ -33,6 +38,10 @@ target_include_directories(ThreadComms PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 set_property(TARGET ThreadComms PROPERTY PUBLIC_HEADER
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub.h
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub.hpp
+    ${ThreadComms_SOURCE_DIR}/include/AggUpdate.h
+    ${ThreadComms_SOURCE_DIR}/include/AggPipePub_MessageAdaption.h
     ${ThreadComms_SOURCE_DIR}/include/IPostable.h
     ${ThreadComms_SOURCE_DIR}/include/PipePublisher.h
     ${ThreadComms_SOURCE_DIR}/include/PipePublisher.hpp
@@ -43,7 +52,7 @@ set_property(TARGET ThreadComms PROPERTY PUBLIC_HEADER
 
 add_executable(publisherSpeed src/publisherSpeed.cpp src/dummy.cpp)
 target_link_libraries(publisherSpeed ThreadComms UtilTime::Time)
-target_compile_features(publisherSpeed PRIVATE cxx_std_14)
+target_compile_features(publisherSpeed PRIVATE cxx_std_17)
 
 #
 # Test Configuration
@@ -52,11 +61,15 @@ find_package(GTest REQUIRED)
 
 add_executable(pipe test/pipe.cpp)
 target_link_libraries(pipe ThreadComms GTest::GTest GTest::Main)
-target_compile_features(pipe PRIVATE cxx_std_14)
+target_compile_features(pipe PRIVATE cxx_std_17)
+
+add_executable(agg test/agg.cpp include/AggPipePub.h)
+target_link_libraries(agg ThreadComms UtilTime::Time GTest::GTest GTest::Main)
+target_compile_features(agg PRIVATE cxx_std_17)
 
 add_executable(worker test/worker.cpp)
 target_link_libraries(worker PRIVATE ThreadComms UtilTime::Time GTest::GTest GTest::Main)
-target_compile_features(worker PRIVATE cxx_std_14)
+target_compile_features(worker PRIVATE cxx_std_17)
 
 #
 # NOTE: Valgrind must be configured *before* testing is imported
@@ -67,6 +80,7 @@ include (CTest)
 
 enable_testing()
 add_test(pipe pipe)
+add_test(agg agg)
 add_test(worker worker)
 
 #

--- a/include/AggPipePub.h
+++ b/include/AggPipePub.h
@@ -1,0 +1,164 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#ifndef THREADCOMMS_AGGPIPEPUB_H
+#define THREADCOMMS_AGGPIPEPUB_H
+
+#include <PipePublisher.h>
+#include <AggUpdate.h>
+#include <map>
+
+#include <AggPipePub_MessageAdaption.h>
+
+namespace AggPipePub_Config {
+    enum class AggPipePubUpdateMode {
+        SKIP_DUPLICATES,
+        NO_DUPLICATE_CHECKING
+    };
+}
+
+// Aggregated Data Update Publisher
+//
+// This is a special variant of the PipePublisher, designed to throttle
+// update notices, protecting client threads that have perform expensive
+// operations on each update.
+//
+// The primary use case is model a remote data-set, over a potentially
+// flakey connection. The interface wrapping an AggPipePub may recover
+// and only notify the
+//
+//  Remote                  Remote Interface            Client
+//                        (Adapting AggPipePub)
+//  SYSTEM START
+//     |              <--Subscribe-- |                          |
+//     | -- Initial Data {0,1,2} --> |                          |
+//     |                             |  --    NEW {0} -->       |
+//     |                             |  --    NEW {1} -->       |
+//     |                             |  --    NEW {2} -->       |
+//     | -- Update {1} -->           |                          |
+//     |                             |  -- UPDATE {1} -->       |
+//     | -- Update {2} -->           |                          |
+//                                  /* {2} unchanged - No update  */
+//     | -- Update {3} -->           |                          |
+//     |                             |  --    NEW {3} -->       |
+//  Remote disconnect - wait for reconnect
+//  ...
+//  Remote reconnected - determine missed updates
+//     |              <--Subscribe-- |                          |
+//     |-- Initial Data {0,1,3,4}--> |                          |
+//                                  /* {0} unchanged - No update  */
+//     |                             |  -- UPDATE {1} -->       |
+//     |                             |  -- DELETE {2} -->       |
+//                                  /* {3} unchanged - No update  */
+//     |                             |  --    NEW {4} -->       |
+//
+// NOTE: Unlike the underlying PipePublisher, the AggPub publishes a
+//       shared_ptr to the Message, rather than performing a full copy
+//       to each thread.
+template <class Message,
+          AggPipePub_Config::AggPipePubUpdateMode updateMode =
+              AggPipePub_Config::AggPipePubUpdateMode::SKIP_DUPLICATES>
+class AggPipePub {
+public:
+// PUBLIC TYPE DEFINITIONS
+
+    // Shared Reference to the Message will be published to each subscriber
+    // thread.
+    using MsgRef = std::shared_ptr<const Message>;
+
+    // The AggUpdate wraps a MsgRef with an update type, so clients know
+    // whether the message is a NEW insert for this id, or an UPDATE to
+    // an already published
+    using Upd = AggUpdate<Message>;
+
+    // Clients subscribe using a standard PipeSubscriber object.
+    using Client = PipeSubscriber<Upd>;
+    using ClientRef = std::shared_ptr<Client>;
+
+// PUBLIC INTERFACE
+    // Nothing special required for construction.
+    AggPipePub() = default;
+
+    // Push a new Message into the data set. Existing clients will
+    // get a NEW if they this is the first time the id has been seen,
+    // and an UPDATE otherwise.
+    //
+    // Clients who subscribe after the message has been processed will
+    // see the update as a NEW when they get their initial data (the
+    // latest message per id)
+    //
+    // NOTE: Due to the use of a PipePublisher, only *ONE THREAD* is allowed
+    //       to publish (ever). Although not strictly required, convention is
+    //       that it is the same thread that constructed the AggPipePub.
+    void Update(MsgRef msg);
+
+    // Reset the the set of messages to exactly match the set defined by
+    // msgs. (see disconnect / reconnect example in class documentation)
+    //
+    // After the reset is complete the client will recieve (in ID sort
+    // order):
+    //   - DELETEs for any messages previously published, never deleted,
+    //     that are not present in msgs
+    //   - UPDATEs for any messages previously published, never deleted,
+    //     which have changed
+    //   - INSERTs for any messages not previously published, or
+    //     previously published and then deleted
+    void ResetMessages(const std::vector<MsgRef>& msgs);
+
+    // Register a new client.
+    //
+    // This is a standard PipeSubscriber object, receiving update publication
+    // when data changes (see comment against the Update method).
+    //
+    // The client will be pre-loaded with the existing data set - a NEW update
+    // for each unique idea that has already been seen by the publisher.
+    //
+    // NOTE: The publisher is locked during construction, and no further updates
+    //       may be posted until the client has been successfully initialised.
+    //
+    // NOTE: See note on threading restrctions documented on PipeSubscriber.
+    std::shared_ptr<PipeSubscriber<Upd>> NewClient(const size_t& maxQueueSize);
+
+private:
+    static constexpr bool diffUpdates =
+            (updateMode != AggPipePub_Config::AggPipePubUpdateMode::NO_DUPLICATE_CHECKING);
+
+    using Adapter = AggPipePub_Adaption::MessageAdapter<Message, diffUpdates>;
+    using IdType = typename Adapter::GetAggIdValueType;
+
+
+    constexpr const IdType GetId(const Message& m) {
+        return Adapter::Get(m);
+    }
+
+    constexpr bool IsUpdated(const Message& orig, const Message& n)
+    {
+        if (diffUpdates) {
+            return !Adapter::IsEqual(orig, n);
+        } else {
+            return true;
+        }
+    }
+
+    class LockedData {
+    public:
+        using DataType = std::map<IdType, MsgRef>;
+        void WithData(const std::function<void (DataType& data)>&);
+    private:
+        std::mutex   dataMutex;
+        DataType data;
+    };
+    LockedData dataStore;
+    Upd ManufactureUpdate(MsgRef msg);
+    Upd ManufactureNewUpdate(MsgRef msg);
+    PipePublisher<Upd> pub_;
+};
+
+template <class Message>
+using NonChecking_AggPipePub =
+        AggPipePub<
+               Message,
+               AggPipePub_Config::AggPipePubUpdateMode::NO_DUPLICATE_CHECKING>;
+
+#include <AggPipePub.hpp>
+#endif //THREADCOMMS_AGGPIPEPUB_H

--- a/include/AggPipePub.hpp
+++ b/include/AggPipePub.hpp
@@ -1,0 +1,123 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#ifndef THREADCOMMS_AGGPIPEPUB_HPP
+#define THREADCOMMS_AGGPIPEPUB_HPP
+#include <AggPipePub.h>
+
+template<class Message,
+         AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message, updateMode>::ClientRef
+    AggPipePub<Message,updateMode>::NewClient(const size_t& max)
+{
+    std::vector<Upd> initialData;
+    dataStore.WithData([&] (auto& data) -> void {
+        initialData.reserve(data.size());
+        for ( const auto& pair: data) {
+            initialData.push_back(ManufactureNewUpdate(pair.second));
+        }
+    });
+
+    return pub_.template NewClient<Client>(max, std::move(initialData));
+}
+
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+void AggPipePub<Message,updateMode>::Update(MsgRef m) {
+    auto upd = ManufactureUpdate(std::move(m));
+    if (upd.updateType != AggUpdateType::NONE) {
+        pub_.Publish(std::move(upd));
+    }
+}
+
+template<class Message, AggPipePub_Config::AggPipePubUpdateMode updateMode>
+void AggPipePub<Message, updateMode>::ResetMessages(const std::vector<MsgRef>& msgs) {
+    typename LockedData::DataType newMap;
+    for (const MsgRef& msg: msgs) {
+        newMap[GetId(*msg)] = msg;
+    }
+
+    dataStore.WithData([&] (auto& existingData) -> void {
+        auto existingIt = existingData.begin();
+        auto newIt = newMap.begin();
+
+        while (existingIt != existingData.end() && newIt != newMap.end()) {
+            MsgRef existing = existingIt->second;
+            MsgRef newEl = newIt->second;
+
+            const auto eid = GetId(*existing);
+            const auto nid = GetId(*newEl);
+
+            if (eid == nid) {
+                if (IsUpdated(*existing, *newEl)) {
+                    pub_.Publish({newEl, AggUpdateType::UPDATE});
+                }
+                ++existingIt;
+                ++newIt;
+            } else if (eid < nid) {
+                pub_.Publish({existing, AggUpdateType::DELETE});
+                ++existingIt;
+            } else if (eid > nid) {
+                pub_.Publish({newEl, AggUpdateType::NEW});
+                ++newIt;
+            }
+        }
+
+        while (existingIt != existingData.end()) {
+            pub_.Publish({existingIt->second, AggUpdateType::DELETE});
+            ++existingIt;
+        }
+
+        while (newIt != newMap.end()) {
+            pub_.Publish({newIt->second, AggUpdateType::NEW});
+            ++newIt;
+        }
+
+        existingData = std::move(newMap);
+    });
+}
+
+
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message, updateMode>::Upd
+    AggPipePub<Message,updateMode>::ManufactureUpdate(AggPipePub::MsgRef m)
+{
+    AggUpdateType updType = AggUpdateType::NEW;
+    const auto id = GetId(*m);
+
+    dataStore.WithData([&] (auto& data) -> void {
+        auto it = data.find(id);
+        if (it == data.end()) {
+            data[id] = m;
+        } else if (IsUpdated(*it->second, *m)) {
+            data.erase(it);
+            updType = AggUpdateType::UPDATE;
+            data[id] = m;
+        } else {
+            updType = AggUpdateType::NONE;
+        }
+    });
+
+    return Upd{std::move(m), updType};
+}
+
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+typename AggPipePub<Message,updateMode>::Upd
+    AggPipePub<Message,updateMode>::ManufactureNewUpdate(AggPipePub::MsgRef msg)
+{
+    return AggPipePub::Upd{msg, AggUpdateType::NEW};
+}
+
+template<class Message,
+        AggPipePub_Config::AggPipePubUpdateMode updateMode>
+void AggPipePub<Message,updateMode>::LockedData::WithData(
+        const std::function<void(DataType &data)>& task)
+{
+    std::unique_lock<std::mutex> lock(dataMutex);
+    task(data);
+}
+
+
+#endif //THREADCOMMS_AGGPIPEPUB_HPP

--- a/include/AggPipePub_MessageAdaption.h
+++ b/include/AggPipePub_MessageAdaption.h
@@ -1,0 +1,169 @@
+//
+// Created by lukeh on 13/10/2019.
+//
+
+#ifndef THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H
+#define THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H
+
+namespace AggPipePub_Adaption {
+
+    /*****************************************
+     *    Does Message have a GetAggId()?
+     *****************************************/
+    template<class Message, bool result = std::is_member_function_pointer<decltype(&Message::GetAggId)>::value>
+    constexpr bool HasGetAggId(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasGetAggId(...) { return false; }
+
+    /*****************************************
+     *    Does Message have a id member?
+     *****************************************/
+    template<class Message, bool result = std::is_member_object_pointer<decltype(&Message::id)>::value>
+    constexpr bool HasId(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasId(...) { return false; }
+
+    /*****************************************************
+     *    Does the Message provide an IsAggEqual method?
+     *****************************************************/
+    template<class Message, bool result = std::is_member_function_pointer<decltype(&Message::IsAggEqual)>::value>
+    constexpr bool HasAggEqual(int) { return result; }
+
+    template<class Message>
+    constexpr bool HasAggEqual(...) { return false; }
+
+    /******************************************************
+     *    Provide ID Access to a Message that has a valid
+     *    GetAggId method.
+     *
+     *    NOTE: We still be a valid object if it doesn't
+     *          to ensure both types of enable_if are
+     *          valid - HOWEVER, we don't require working
+     *          getters / types in that scenario
+     ******************************************************/
+    template<class Message, bool HasGetter>
+    struct GetIdAdp {
+        using GetAggIdResultType =
+        typename std::conditional<
+                HasGetter,
+                decltype(((Message*)(nullptr))->GetAggId()),
+                nullptr_t>::type;
+        using GetAggIdValueType =
+                typename std::remove_reference<GetAggIdResultType>::type;
+
+        using EnableIf_HasGetAggId =
+            typename std::enable_if<HasGetter, GetAggIdValueType>::type;
+
+        static constexpr EnableIf_HasGetAggId Get(const Message& m) {
+            return m.GetAggId();
+        }
+    };
+
+    /******************************************************
+     *    Provide ID Access to a Message that has a valid
+     *    id member variable
+     *
+     *    NOTE: We still be a valid object if it doesn't
+     *          to ensure both types of enable_if are
+     *          valid - HOWEVER, we don't require working
+     *          getters / types in that scenario
+     ******************************************************/
+    template<class Message, bool HasId>
+    struct IdAdp {
+        using GetAggIdResultType =
+        typename std::conditional<
+                HasId,
+                decltype(((Message*)(nullptr))->id),
+                nullptr_t>::type;
+        using GetAggIdValueType  = typename std::remove_reference<GetAggIdResultType>::type;
+
+        using EnableIf_HasId =
+        typename std::enable_if<HasId, GetAggIdValueType>::type;
+
+        static constexpr EnableIf_HasId Get(const Message& m) {
+            return m.id;
+        }
+    };
+
+    /******************************************************
+     *    Diffing adapter that uses the Message's inbuilt
+     *    diffing operator (IsAggEqual) to determine whether
+     *    clients should be notifed of an update.
+     *
+     *
+     *    NOTE: We still require a valid object, even if
+     *          Message doesn't have the comparator
+     ******************************************************/
+    template<class Message, bool HasComparator>
+    struct IsEqUpdateChecker {
+        using EnableIf_HasComparator =
+        typename std::enable_if<HasComparator, bool>::type;
+
+        static constexpr EnableIf_HasComparator IsEq(
+            const Message& orig,
+            const Message& upd)
+        {
+            return orig.IsAggEqual(upd);
+        }
+    };
+
+    template<class Message>
+    struct NoDiffingChecker {
+        static constexpr bool IsEq(const Message& orig, const Message& upd) {
+            return false;
+        }
+    };
+
+    /******************************************************
+     *  Adapt the message type to provide access to the Id
+     *  field.
+     ******************************************************/
+    template<class Message, bool requiresIsEq>
+    struct MessageAdapter {
+        static constexpr bool hasGetAggId = HasGetAggId<Message>(0);
+        static constexpr bool hasId = HasId<Message>(0);
+        static constexpr bool hasAggEq = HasAggEqual<Message>(0);
+
+        // Ensure the message as at least one way of accessing the id type
+        static_assert(hasGetAggId || hasId,
+                       "Message object has no viable Id Type!"
+                       " Object must provide one of :\n"
+                       "   struct Message { \n"
+                       "        <id type> id;\n"
+                       "        <id type> GetAggId() const;"
+                       "   };");
+
+        static_assert(!requiresIsEq || hasAggEq,
+                      "Message object has no IsAggEqual method, but update"
+                      " diffing was requestd!");
+
+
+        using GetAdapter =
+            typename std::conditional<
+                         hasGetAggId,
+                         GetIdAdp<Message, hasGetAggId>,
+                         IdAdp<Message, hasId>>::type;
+
+        using GetAggIdValueType  = typename GetAdapter::GetAggIdValueType;
+
+        static constexpr GetAggIdValueType Get(const Message& m) {
+            return GetAdapter::Get(m);
+        }
+
+        using DiffAdapter =
+            typename std::conditional<
+                    hasAggEq,
+                    IsEqUpdateChecker<Message, hasAggEq>,
+                    NoDiffingChecker<Message>>::type;
+
+        static constexpr bool IsEqual(const Message& orig, const Message& upd)
+        {
+            return DiffAdapter::IsEq(orig, upd);
+        }
+    };
+}
+
+
+#endif //THREADCOMMS_AGGPIPEPUB_MESSAGEADAPTION_H

--- a/include/AggUpdate.h
+++ b/include/AggUpdate.h
@@ -1,0 +1,37 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+
+#ifndef THREADCOMMS_AGGUPDATE_H
+#define THREADCOMMS_AGGUPDATE_H
+#include <memory>
+
+enum class AggUpdateType: char {
+    NEW ='N',
+    UPDATE ='U',
+    DELETE ='D',
+    NONE ='O',
+};
+
+std::ostream& operator<<(std::ostream& os, const AggUpdateType& up) {
+    switch (up) {
+        case AggUpdateType::NEW:
+            os << "AggUpdateType::NEW";
+            break;
+        case AggUpdateType::UPDATE:
+            os << "AggUpdateType::UPDATE";
+            break;
+        default:
+            os << "AggUpdateType::UNKNOWN";
+            break;
+    }
+    return os;
+}
+
+template<class T>
+struct AggUpdate {
+    std::shared_ptr<const T> data;
+    AggUpdateType            updateType;
+};
+
+#endif //THREADCOMMS_AGGUPDATE_H

--- a/include/PipePublisher.h
+++ b/include/PipePublisher.h
@@ -43,7 +43,7 @@ public:
      * @param  maxSize  Maximum number of unread messages
      */
     template <class Client = PipeSubscriber<Message>, class... Args>
-    std::shared_ptr<Client> NewClient(Args... args);
+    std::shared_ptr<Client> NewClient(Args&&... args);
 
     void InstallClient(std::shared_ptr<IPipeConsumer<Message>> client);
 

--- a/include/PipePublisher.hpp
+++ b/include/PipePublisher.hpp
@@ -93,8 +93,8 @@ void PipePublisher<Message>::Publish(const Message& msg) {
 
 template <class Message>
 template <class Client, class... Args>
-std::shared_ptr<Client> PipePublisher<Message>::NewClient(Args... args) {
-    std::shared_ptr<Client> client (new Client(this, args...));
+std::shared_ptr<Client> PipePublisher<Message>::NewClient(Args&&... args) {
+    std::shared_ptr<Client> client (new Client(this, std::forward<Args>(args)...));
     InstallClient(client);
     return client;
 

--- a/include/PipeSubscriber.h
+++ b/include/PipeSubscriber.h
@@ -123,7 +123,8 @@ private:
  * pipe.
  */
 template <class Message,
-          class NewMessageCallback = std::function<void(const Message&)> >
+         class NextMessageCallback = std::function<void()>,
+         class NewMessageCallback = std::function<void(const Message&)> >
 class PipeSubscriber: public IPipeConsumer<Message> {
 public:
 
@@ -170,7 +171,6 @@ public:
      * NOTE: This callback may be triggered immediately (before returning) on
      *        the current thread if there is already unread data on the queue.
      */
-    typedef std::function<void(void)> NextMessageCallback;
     void OnNextMessage(const NextMessageCallback& f);
 
     /**

--- a/include/PipeSubscriber.h
+++ b/include/PipeSubscriber.h
@@ -122,7 +122,8 @@ private:
  * onMessage notification. (Choosing not to use trigger results in a lockless
  * pipe.
  */
-template <class Message>
+template <class Message,
+          class NewMessageCallback = std::function<void(const Message&)> >
 class PipeSubscriber: public IPipeConsumer<Message> {
 public:
 
@@ -195,8 +196,7 @@ public:
      * NOTE: To preserve ordering this function will lock out the publisher thread
      *       until call-backss for all existing messages haeve been completed.
      */
-    typedef std::function<void(const Message&)> NewMessasgCallback;
-    void OnNewMessage(const NewMessasgCallback&  f);
+    void OnNewMessage(const NewMessageCallback&  f);
 
     /*
      * Has the publisher finished?
@@ -343,7 +343,7 @@ private:
     /***********************************
      * Forward Messages
      ***********************************/
-    NewMessasgCallback   onNewMessage;
+    NewMessageCallback   onNewMessage;
     std::atomic<bool>    forwardMessage;
 
     /*********************************

--- a/include/PipeSubscriber.h
+++ b/include/PipeSubscriber.h
@@ -219,7 +219,8 @@ protected:
      */
     PipeSubscriber(
         PipePublisher<Message>* parent,
-        size_t maxSize);
+        size_t maxSize,
+        std::vector<Message> initData = {});
 
      struct PushToFullQueueException {
          Message msg;

--- a/include/PipeSubscriber.hpp
+++ b/include/PipeSubscriber.hpp
@@ -48,7 +48,8 @@ bool IPipeConsumer<Message>::ChangeState(STATE& current, STATE to) {
 template <class Message>
 PipeSubscriber<Message>::PipeSubscriber(
     PipePublisher<Message>* _parent,
-    size_t maxSize)
+    size_t maxSize,
+    std::vector<Message> initialData)
         : notifyState(DISABLED),
           onNotify(nullptr),
           targetToNotify(nullptr),
@@ -58,6 +59,9 @@ PipeSubscriber<Message>::PipeSubscriber(
           messages(maxSize)
 {
     forwardMessage = false;
+    for (const auto& m: initialData ) {
+        PushMessage(m);
+    }
 }
 
 template <class Message>

--- a/include/PipeSubscriber.hpp
+++ b/include/PipeSubscriber.hpp
@@ -427,7 +427,8 @@ void PipeSubscriber<Message, NewMessageCallback>::NotifyConfigured() {
                 break;
 
             case PUB_RECONFIGURING:
-                // Fine - complete the reconfigure
+                // Even if there are messages in the queue, this is fine. The publisher notified its
+                // last write, which means there's nothing new to notify.
                 action = NOTHING;
                 newState = NOTHING_TO_NOTIFY;
                 break;

--- a/include/WorkerThread.h
+++ b/include/WorkerThread.h
@@ -49,8 +49,9 @@ public:
 
     /**
      * Start the worker
+     *  @returns true - the tread was successfully started, false otherwise
      */
-    void Start();
+    bool Start();
 
     /**
      * Join the thread
@@ -85,6 +86,11 @@ public:
         const std::function<void (Msg& m)>& task,
         size_t maxQueueSize = 1000000,
         size_t maxSlizeSize = 100);
+
+    /**
+     * Check if this function was invoked on the actual thread
+     */
+    bool CurrentlyOnWorkerThread() const;
 
 private:
     enum STATE {NOT_STARTED, RUNNING, SLEEPING, STOPPED, ABORTED};
@@ -173,7 +179,7 @@ private:
     std::mutex                   queueMutex;
     std::condition_variable      notification;
     std::list<Job>               workQueue;
-    STATE                        state;
+    std::atomic<STATE>           state;
     std::thread                  worker;
 
     std::vector<std::shared_ptr<void>> clients;

--- a/src/WorkerThread.cpp
+++ b/src/WorkerThread.cpp
@@ -92,10 +92,10 @@ void WorkerThread::Abort() {
 
 bool WorkerThread::Start() {
     bool started = false;
+    std::unique_lock<std::mutex> lock(queueMutex);
     if (state == NOT_STARTED) {
-        std::unique_lock<std::mutex> lock(queueMutex);
         state = RUNNING;
-        worker = std::thread([this] () -> void { this->Run();});
+        worker = std::thread([this]() -> void { this->Run(); });
         started = true;
     }
 

--- a/src/WorkerThread.cpp
+++ b/src/WorkerThread.cpp
@@ -159,6 +159,10 @@ void WorkerThread::Sleep(std::unique_lock<std::mutex>& lock) {
     }
 }
 
+bool WorkerThread::CurrentlyOnWorkerThread() const {
+    return (state != NOT_STARTED) && (std::this_thread::get_id() == worker.get_id());
+}
+
 void WorkerThread::Job::Cancel() {
     if (promised) {
         result.set_value(false);

--- a/src/WorkerThread.cpp
+++ b/src/WorkerThread.cpp
@@ -1,5 +1,5 @@
 /*
- * WorkerThread.cpp
+
  *
  *  Created on: 24 Jan 2016
  *      Author: lhumphreys
@@ -90,12 +90,16 @@ void WorkerThread::Abort() {
     Wake(ABORTED);
 }
 
-void WorkerThread::Start() {
-    if (state != RUNNING) {
+bool WorkerThread::Start() {
+    bool started = false;
+    if (state == NOT_STARTED) {
         std::unique_lock<std::mutex> lock(queueMutex);
         state = RUNNING;
         worker = std::thread([this] () -> void { this->Run();});
+        started = true;
     }
+
+    return started;
 }
 
 void WorkerThread::Join() {

--- a/test/agg.cpp
+++ b/test/agg.cpp
@@ -1,0 +1,523 @@
+//
+// Created by lukeh on 12/10/2019.
+//
+#include <PipePublisher.h>
+#include <gtest/gtest.h>
+#include <AggPipePub.h>
+#include <util_time.h>
+#include <WorkerThread.h>
+
+using namespace std;
+using namespace nstimestamp;
+
+struct Msg {
+    Msg (std::string m, size_t i)
+        : message(std::move(m))
+        , _id(i) {}
+
+    std::string   message;
+    size_t        _id;
+};
+struct IdMsg: public Msg {
+    IdMsg(const Msg& m)
+            : Msg(m), id(m._id) {}
+
+    size_t id;
+};
+struct WrappedMsg: public Msg {
+    WrappedMsg (std::string m, size_t i)
+        : Msg(std::move(m), i) {}
+
+    [[nodiscard]] constexpr const auto& GetAggId() const { return _id;}
+    [[nodiscard]] bool  IsAggEqual (const Msg& other) const {
+        return (message == other.message);
+    }
+};
+using Msgs = std::vector<Msg>;
+
+using MsgAgg = AggPipePub<WrappedMsg>;
+using Upds = std::vector<MsgAgg::Upd>;
+
+struct ExpUpd {
+    Msg           m;
+    AggUpdateType updateType = AggUpdateType::NONE;
+};
+using ExpUpds = std::vector<ExpUpd>;
+
+using ClientRef = std::shared_ptr<PipeSubscriber<MsgAgg::Upd>>;
+
+void MessagesMatch(ExpUpds& exp, Upds& got)
+{
+    ASSERT_EQ(exp.size(), got.size());
+
+    for (size_t i = 0; i < exp.size(); ++i) {
+        const Msg& msg = exp[i].m;
+        const Msg& recvd = *got[i].data;
+        ASSERT_EQ(msg.message, recvd.message);
+        ASSERT_EQ(msg._id, recvd._id);
+
+        ASSERT_EQ(exp[i].updateType, got[i].updateType);
+    }
+}
+
+void Publish(MsgAgg& pub, const Msg& m) {
+    auto cpy = std::make_shared<WrappedMsg>(m.message, m._id);
+    pub.Update(std::move(cpy));
+}
+void Publish(MsgAgg& pub, const Msgs& msgs) {
+    for (const Msg& m: msgs) {
+        Publish(pub, m);
+    }
+}
+
+void ResetMessages(MsgAgg& pub, Msgs& toReplay) {
+    std::vector<std::shared_ptr<const WrappedMsg>> msgs;
+    msgs.reserve(toReplay.size());
+    for (const Msg& m: toReplay) {
+        msgs.emplace_back(std::make_shared<const WrappedMsg>(m.message, m._id));
+    }
+
+    pub.ResetMessages(msgs);
+}
+
+void GetMessages(const size_t toGet, ClientRef& cli, Upds& dest) {
+    MsgAgg::Upd upd;
+    for (size_t i = 0; i < toGet; ++i) {
+        ASSERT_TRUE(cli->GetNextMessage(upd));
+        dest.push_back(upd);
+    }
+}
+
+void CheckClient(ClientRef client, ExpUpds& exp) {
+    Upds got;
+    ASSERT_NO_FATAL_FAILURE(GetMessages(exp.size(), client, got));
+    ASSERT_NO_FATAL_FAILURE(MessagesMatch(exp, got));
+}
+
+void PublishAndCheck (Msgs& toSend, ExpUpds& exp) {
+    MsgAgg pub;
+    ClientRef client = pub.NewClient(1024);
+
+    Publish(pub, toSend);
+    CheckClient(client, exp);
+}
+
+void PublishReplayAndCheck (Msgs& toSend, Msgs& toReplay, ExpUpds& exp, ExpUpds& expReplay) {
+    MsgAgg pub;
+    ClientRef client = pub.NewClient(1024);
+
+    Publish(pub, toSend);
+    ASSERT_NO_FATAL_FAILURE(CheckClient(client, exp));
+
+    ResetMessages(pub, toReplay);
+    ASSERT_NO_FATAL_FAILURE(CheckClient(client, expReplay));
+}
+
+/*
+ * As updates for new items arrive, they are immediately
+ * published to any subscribed clients. They'll be published
+ * with an updateType of NEW
+ */
+TEST(TAggPuplisher,NewItems) {
+    Msgs toSend{
+        Msg{"Hello World!", 0},
+        Msg{"A new message", 1},
+        Msg{"Yet another message", 2}
+    };
+
+    ExpUpds exp{
+        {toSend[0], AggUpdateType::NEW},
+        {toSend[1], AggUpdateType::NEW},
+        {toSend[2], AggUpdateType::NEW}
+    };
+
+    PublishAndCheck(toSend, exp);
+}
+
+
+/*
+ * When an existing item is updated, with a new value, it
+ * is published to clients with an updateType of UPDATE
+ */
+TEST(TAggPuplisher,UpdatedItems) {
+    Msgs toSend {
+        Msg{"Hello World!", 0},
+        Msg{"A new message", 1},
+        Msg{"Hello New World!", 0},
+        Msg{"Yet another message", 2}
+    };
+
+    ExpUpds exp {
+        {toSend[0], AggUpdateType::NEW},
+        {toSend[1], AggUpdateType::NEW},
+        {toSend[2], AggUpdateType::UPDATE},
+        {toSend[3], AggUpdateType::NEW}
+    };
+    PublishAndCheck(toSend, exp);
+}
+
+/*
+ * If diffing has been disabled, then all updates should be broadcast,
+ * regardless of whether a material change has happened to the object.
+ *
+ * The Msg is not required to provide a diffing util.
+ */
+TEST(TAggPuplisher,UpdatedItems_NoDiffing) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Hello New World!", 0},
+            Msg{"Hello New World!", 0},
+            Msg{"Yet another message", 2}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[2], AggUpdateType::UPDATE},
+            {toSend[3], AggUpdateType::UPDATE},
+            {toSend[4], AggUpdateType::NEW}
+    };
+    NonChecking_AggPipePub<IdMsg> pub;
+    auto client = pub.NewClient(64);
+    for (auto m: toSend) {
+        auto mref = std::make_shared<IdMsg>(m);
+        pub.Update(std::move(mref));
+    }
+
+    NonChecking_AggPipePub<IdMsg>::Upd upd;
+    for (size_t i = 0; i < exp.size(); ++i) {
+        ASSERT_TRUE(client->GetNextMessage(upd));
+        ASSERT_EQ(upd.updateType, exp[i].updateType);
+        ASSERT_EQ(upd.data->message, exp[i].m.message);
+        ASSERT_EQ(upd.data->_id, exp[i].m._id);
+    }
+    ASSERT_FALSE(client->GetNextMessage(upd));
+}
+
+/*
+ * If an existing item is updated, but has not changed, then
+ * the update is *not* re-published
+ *
+ */
+TEST(TAggPuplisher,NoDiffNoUpdate) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Hello World!", 0},
+            Msg{"Yet another message", 2},
+            Msg{"Hello New World!", 0},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            // Update [2] is skipped, as there is no material change
+            {toSend[3], AggUpdateType::NEW},
+            {toSend[4], AggUpdateType::UPDATE},
+            {toSend[5], AggUpdateType::NEW},
+    };
+    PublishAndCheck(toSend, exp);
+}
+
+TEST(TAggPuplisher,LateSubscriber) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Hello World!", 0},
+            Msg{"Yet another message", 2},
+            Msg{"Hello New World!", 0},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            // Update [2] is skipped, as there is no material change
+            {toSend[3], AggUpdateType::NEW},
+            {toSend[4], AggUpdateType::UPDATE},
+            {toSend[5], AggUpdateType::NEW},
+    };
+
+    MsgAgg pub;
+    ClientRef client = pub.NewClient(1024);
+
+    Publish(pub, toSend);
+    CheckClient(client, exp);
+
+    ExpUpds lateUpdates {
+            {toSend[4], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[3], AggUpdateType::NEW},
+            {toSend[5], AggUpdateType::NEW},
+    };
+
+    ClientRef lateClient = pub.NewClient(1024);
+    CheckClient(lateClient, lateUpdates);
+}
+
+/*
+ * If when the data is replayed nothing has changed - then no updates are
+ * pushed to the subscriber
+ *
+ */
+TEST(TAggPuplisher_Replay,NoDiffNoUpdate) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Yet another message", 2},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[2], AggUpdateType::NEW},
+            {toSend[3], AggUpdateType::NEW},
+    };
+    ExpUpds expReplay {};
+    PublishReplayAndCheck(toSend, toSend, exp, expReplay);
+}
+
+/*
+ * If data is updated, or inserted during replay - updates
+ * are sent to clients
+ *
+ */
+TEST(TAggPuplisher_Replay,InsertsAndUpdates) {
+    Msgs toSend {
+            Msg{"A new message", 1},
+            Msg{"Yet another message", 2},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[2], AggUpdateType::NEW},
+    };
+
+    Msgs toReplay {
+        Msg{"Hello World!", 0},
+        Msg{"A new message", 1},
+        Msg{"UPDATED!", 2},
+        Msg{"Yet another message", 3},
+        Msg{"NEW!", 4}
+    };
+    ExpUpds expReplay {
+            {toReplay[0], AggUpdateType::NEW},
+            {toReplay[2], AggUpdateType::UPDATE},
+            {toReplay[4], AggUpdateType::NEW}
+    };
+    PublishReplayAndCheck(toSend, toReplay, exp, expReplay);
+}
+
+/*
+ * If data has been removed, then it is deleted when the replay is complete
+ */
+TEST(TAggPuplisher_Replay,Deletes) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Yet another message", 2},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[2], AggUpdateType::NEW},
+            {toSend[3], AggUpdateType::NEW},
+    };
+
+    Msgs toReplay {
+            Msg{"UPDATED!", 2},
+            Msg{"NEW!", 4}
+    };
+    ExpUpds expReplay {
+            {toSend[0], AggUpdateType::DELETE},
+            {toSend[1], AggUpdateType::DELETE},
+            {toReplay[0], AggUpdateType::UPDATE},
+            {toSend[3], AggUpdateType::DELETE},
+            {toReplay[1], AggUpdateType::NEW}
+    };
+    PublishReplayAndCheck(toSend, toReplay, exp, expReplay);
+}
+
+/*
+ * If data has been removed, then it is deleted when the replay is complete
+ */
+TEST(TAggPuplisher_Replay,DeletesMost) {
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Yet another message", 2},
+            Msg{"Yet another message", 3}
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[2], AggUpdateType::NEW},
+            {toSend[3], AggUpdateType::NEW},
+    };
+
+    Msgs toReplay {
+            Msg{"UPDATED!", 1},
+    };
+    ExpUpds expReplay {
+            {toSend[0], AggUpdateType::DELETE},
+            {toReplay[0], AggUpdateType::UPDATE},
+            {toSend[2], AggUpdateType::DELETE},
+            {toSend[3], AggUpdateType::DELETE}
+    };
+    PublishReplayAndCheck(toSend, toReplay, exp, expReplay);
+}
+
+
+/*
+ * The above test define the basic behaviourial properties
+ * of the AggPub - but in reality we expect each sub to
+ * be on their own thread.
+ *
+ * This first threaded test replicates the basic flow,
+ * without trying to force any potential race conditions
+ */
+TEST(TAggPuplisherThreads,BasicFlow) {
+    WorkerThread pubThread;
+    WorkerThread clientThread;
+    WorkerThread lateClientThread;
+    pubThread.Start();
+    clientThread.Start();
+    lateClientThread.Start();
+
+    Msgs toSend {
+            Msg{"Hello World!", 0},
+            Msg{"A new message", 1},
+            Msg{"Hello World!", 0},
+            Msg{"Yet another message", 2},
+            Msg{"Hello New World!", 0},
+            Msg{"Yet another message", 3}
+    };
+
+    Msgs toSend_late {
+            Msg{"Hello New World!", 0},
+            Msg{"A new message", 4},
+            Msg{"Brand new 0", 0},
+    };
+
+    ExpUpds exp {
+            {toSend[0], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            // Update [2] is skipped, as there is no material change
+            {toSend[3], AggUpdateType::NEW},
+            {toSend[4], AggUpdateType::UPDATE},
+            {toSend[5], AggUpdateType::NEW},
+            // late [0] is skipped, as there is no material change
+            {toSend_late[1], AggUpdateType::NEW},
+            {toSend_late[2], AggUpdateType::UPDATE},
+    };
+
+    ExpUpds lateUpdates {
+            {toSend[4], AggUpdateType::NEW},
+            {toSend[1], AggUpdateType::NEW},
+            {toSend[3], AggUpdateType::NEW},
+            {toSend[5], AggUpdateType::NEW},
+            // late [0] is skipped, as there is no material change
+            {toSend_late[1], AggUpdateType::NEW},
+            {toSend_late[2], AggUpdateType::UPDATE},
+    };
+
+    MsgAgg pub;
+    ClientRef client, lateClient;
+
+    clientThread.DoTask([&] () -> void {
+        client = pub.NewClient(1024);
+    });
+
+    pubThread.DoTask([&] () -> void {
+        Publish(pub, toSend);
+    });
+
+    lateClientThread.DoTask([&] () -> void {
+        lateClient = pub.NewClient(1024);
+    });
+
+    pubThread.DoTask([&] () -> void {
+        Publish(pub, toSend_late);
+    });
+
+    clientThread.DoTask([&] () -> void {
+        CheckClient(client, exp);
+    });
+
+    lateClientThread.DoTask([&] () -> void {
+        CheckClient(lateClient, lateUpdates);
+    });
+}
+
+/*
+ * We have to be careful when installing a late subscriber -
+ * the client thread will attempt to traverse publisher's data
+ * store to build an intiial image.
+ *
+ * *However*, if the publisher thread is attempting to publish
+ * at the same time, it might be trying to delete / update from
+ * that store.
+ *
+ * We're optimizing for the case where installing a client is rare
+ * - as a result, a simple lock around the data store is acceptable.
+ */
+TEST(TAggPuplisherThreads,LastSubFastPubRace) {
+    struct IdStamp {
+        IdStamp (size_t id)
+          : id(id)
+        {
+            stamp.SetNow();
+        }
+
+        size_t id    = 0;
+        Time   stamp = Time().SetNow();
+    };
+    using IdPub = NonChecking_AggPipePub<IdStamp>;
+    using IdPubRef = std::shared_ptr<IdPub>;
+    using IdClientRef = IdPub::ClientRef;
+
+    IdPubRef pub = std::make_shared<IdPub>();
+    IdClientRef client;
+    std::atomic_bool clientDone = false;
+
+    WorkerThread pubThread, clientThread;
+
+    auto loadData =  [&] () -> void {
+        for (size_t i = 0; i < 10; ++i) {
+            pub->Update(std::make_shared<IdStamp>(i));
+        }
+    };
+
+    pubThread.Start();
+    pubThread.DoTask([&] () -> void {
+            loadData();
+    });
+
+    pubThread.PostTask([&] () -> void {
+        while (!clientDone) {
+            loadData();
+        }
+    });
+
+    clientThread.Start();
+    clientThread.DoTask([&] () -> void {
+        client = pub->NewClient(102400);
+        clientDone = true;
+        // The first ten items, should be the first 10 ids: since
+        // this is the initial data set.
+        for (size_t i = 0; i < 10; ++i) {
+            AggUpdate<IdStamp> upd;
+            ASSERT_TRUE(client->GetNextMessage(upd));
+            ASSERT_EQ(i, upd.data->id);
+            ASSERT_EQ(AggUpdateType::NEW, upd.updateType);
+        }
+    });
+}

--- a/test/pipe.cpp
+++ b/test/pipe.cpp
@@ -82,8 +82,8 @@ TEST(TPipeSubscriber,Notify) {
 }
 
 TEST(TPipeSubscriber,WaitForMessage) {
-    WorkerThread pushThread;
     PipePublisher<Msg> publisher;
+    WorkerThread pushThread;
     std::shared_ptr<PipeSubscriber<Msg>> client(publisher.NewClient(1024));
     std::vector<Msg> toSend = {
         {"Message 1"},
@@ -285,6 +285,26 @@ TEST(TPipeSubscriber,ForEachData) {
     }
 
     ASSERT_NO_FATAL_FAILURE(MessagesMatch(toSend,got));
+}
+
+TEST(TPipeSubscriber,InitialData) {
+    PipePublisher<Msg> publisher;
+    std::vector<Msg> toSend = {
+            {"Message 1"},
+            {"Mesasge 2"},
+            {"Hello World!"}
+    };
+    auto sent = toSend;
+    std::shared_ptr<PipeSubscriber<Msg>> client(publisher.NewClient(1024, std::move(toSend)));
+
+    std::vector<Msg> got;
+    auto f = [&] (const Msg& newMsg) -> void {
+        got.push_back(newMsg);
+    };
+
+    client->OnNewMessage(f);
+
+    ASSERT_NO_FATAL_FAILURE(MessagesMatch(sent,got));
 }
 
 TEST(TPipeSubscriber,BatchForEachData) {

--- a/test/pipe_state_model.cpp
+++ b/test/pipe_state_model.cpp
@@ -1,0 +1,207 @@
+#include <PipePublisher.h>
+#include <gtest/gtest.h>
+#include <WorkerThread.h>
+
+struct Msg {
+    std::string   message;
+};
+
+struct InvokeOnCopyFunction {
+    std::function<void ()> f;
+    std::function<void()> onCopy = [] () -> void {};
+    std::function<void()> onMove = [] () -> void {};
+
+    InvokeOnCopyFunction() = default;
+    InvokeOnCopyFunction(nullptr_t null): f(null) {}
+
+    void operator() () const {
+        f();
+    }
+    explicit operator const std::function<void ()>&() const { return f;}
+
+    InvokeOnCopyFunction(InvokeOnCopyFunction&& rhs) {
+        (*this) = std::move(rhs);
+    }
+    InvokeOnCopyFunction& operator=(InvokeOnCopyFunction&& rhs) {
+        rhs.onMove();
+        f = std::move(rhs.f);
+        onCopy = std::move(rhs.onCopy);
+        onMove = std::move(rhs.onMove);
+
+        return *this;
+    }
+
+    InvokeOnCopyFunction(const InvokeOnCopyFunction& rhs) {
+        (*this) = rhs;
+    }
+    InvokeOnCopyFunction& operator=(const InvokeOnCopyFunction& rhs) {
+        rhs.onCopy();
+        f = rhs.f;
+        onCopy = rhs.onCopy;
+        onMove = rhs.onMove;
+
+        return *this;
+    }
+};
+
+using Client = PipeSubscriber<Msg, InvokeOnCopyFunction>;
+
+void MessagesMatch(const std::vector<Msg>& expected,
+                   const std::vector<Msg>& got)
+{
+    ASSERT_EQ(expected.size(), got.size());
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        const Msg& msg = expected[i];
+        const Msg& recvd = got[i];
+
+        ASSERT_EQ(msg.message, recvd.message);
+    }
+}
+
+/**
+ * In this edge case, the publisher thread completes publication, just as
+ * the trigger is being set by the client thread. It can't safely trigger
+ * whist its being updated, so instead it updates the state to notify the
+ * client it must immediately trigger once it is done configuring
+ *
+ * To actually hit this code we'd have to be very unlucky, so to force it
+ * to happen, we slow down the copy constructor...
+ */
+TEST(TPipeSubscriperStateModel, ClientStillConfiguringAfterPublish) {
+    PipePublisher<Msg> pub;
+    auto client = pub.NewClient<Client>(1024);
+    std::vector<Msg> got;
+
+    std::promise<bool> startedCopy;
+    std::promise<bool> completeCopy;
+
+    WorkerThread clientThread;
+    clientThread.Start();
+    clientThread.PostTask([&] () -> void {
+        // Setup the trigger function to block until we're done publishing...
+        InvokeOnCopyFunction trigger;
+        trigger.onCopy = [&] () -> void {
+            ASSERT_TRUE(completeCopy.get_future().get());
+        };
+        trigger.f = [&] () -> void {
+            Msg m;
+            while (client->GetNextMessage(m))  {
+                got.push_back(m);
+            }
+        };
+
+        startedCopy.set_value(true);
+        client->OnNextMessage(trigger);
+    });
+
+    std::vector<Msg> toSend {
+        {"Message 1"},
+        {"Mesasge 2"},
+        {"Mesasge 3"},
+    };
+
+    if (startedCopy.get_future().get()) {
+        pub.Publish(toSend[0]);
+        pub.Publish(toSend[1]);
+        completeCopy.set_value(true);
+
+        // Flush client thread...
+        clientThread.DoTask([] () -> void {});
+
+        // Final message shouldn't be picked up by the trigger
+        pub.Publish(toSend[2]);
+
+        MessagesMatch({toSend[0], toSend[1]}, got);
+    } else {
+        ASSERT_FALSE(true) << "Failed to start the copy!";
+    }
+
+}
+
+/**
+ * In the following set of edge cases we deal with scenarios where the
+ * client thread attempts to re-configure, *whilst* the publisher is
+ * already publishing. When this happens the client thread will
+ * do an initial copy into the "pending" notification storage. What
+ * happens next depends on state resolution:
+ *
+ *   1. (The publisher is already done) If the publisher completed whilst
+ *      we were budy setting up the pending notify, then its up to us to
+ *      complete the configuration. This essentially returns us to a
+ *      standard CONFIGURING state:
+ *             CLIENT_WILL_RECONFIGURE -> CONFIGURING
+ *      NOTE: If there are still message in the queue, this will result
+ *            in an immediate trigger.
+ */
+
+// See notes on client re-configuring above
+// This test test covers edge case (1)
+TEST(TPipeSubscriperStateModel, ClientWillReConfigure) {
+    std::vector<Msg> toSend {
+            {"Message 1"},
+            {"Mesasge 2"}
+    };
+    std::vector<Msg> got;
+
+    PipePublisher<Msg> pub;
+    auto client = pub.NewClient<Client>(1024);
+
+    std::promise<bool> startedPublishing;
+    std::promise<bool> startedPendingReconfigure;
+
+//STATE: DISABLED
+
+    auto wait = [&] () -> void {
+        startedPublishing.set_value(true);
+        startedPendingReconfigure.get_future().get();
+    };
+    InvokeOnCopyFunction initialTrigger;
+    initialTrigger.f = wait;
+
+    client->OnNextMessage(initialTrigger);
+
+//STATE: NOTHING_TO_NOTIFY
+
+    WorkerThread pubThread, clientThread;
+    pubThread.Start();
+    clientThread.Start();
+
+    pubThread.PostTask([&] () -> void {
+        // NOTE: This will block until the client has started the pending-configure
+        pub.Publish(toSend[0]);
+    });
+
+//STATE: PUBLISHING
+
+    InvokeOnCopyFunction blockingReconfigure;
+    blockingReconfigure.f = [&] () -> void {
+        Msg m;
+        while (client->GetNextMessage(m)) {
+            got.push_back(m);
+        }
+    };
+    blockingReconfigure.onCopy = [&] () -> void {
+        startedPendingReconfigure.set_value(true);
+
+        // Flush the publisher...
+        pubThread.DoTask( [&] () -> void { });
+
+        // Once that message is done, *another* message
+        // comes in: should be picked up  when the client
+        // realises it needs to pull
+        pubThread.DoTask( [&] () -> void {
+            pub.Publish(toSend[1]);
+        });
+
+    };
+
+    clientThread.DoTask([&] () -> void {
+        client->OnNextMessage(blockingReconfigure);
+    });
+
+    MessagesMatch({toSend[0], toSend[1]}, got);
+}
+
+// See notes on client re-configuring above
+// This test test covers edge case (1B)

--- a/test/worker.cpp
+++ b/test/worker.cpp
@@ -239,6 +239,22 @@ TEST(TWorker, NoRestart_AfterAbort) {
 
 }
 
+TEST(TWorker, OnThread) {
+    WorkerThread worker, other;
+    ASSERT_FALSE(worker.CurrentlyOnWorkerThread());
+
+    worker.Start();
+    worker.DoTask([&] () -> void {
+        ASSERT_TRUE(worker.CurrentlyOnWorkerThread());
+    });
+    ASSERT_FALSE(worker.CurrentlyOnWorkerThread());
+
+    other.Start();
+    other.DoTask([&] () -> void {
+        ASSERT_FALSE(worker.CurrentlyOnWorkerThread());
+    });
+}
+
 struct Msg {
     Time t;
     std::string message;


### PR DESCRIPTION
This is a special variant of the PipePublisher, designed to throttle update
notices, protecting client threads that have to perform expensive operations on
each update.

The primary use case is model a remote data-set, over a potentially flakey
connection. The interface wrapping an AggPipePub may recover and only notify
the client threads if something has actually changed. When used in a
Microservices environment this allows components to be abstracted away from 
recovery (although only those components for which is safe to continue with
stale data).

```
 Remote                  Remote Interface            Client
                       (Adapting AggPipePub)
 SYSTEM START
    |              <--Subscribe-- |                          |
    | -- Initial Data {0,1,2} --> |                          |
    |                             |  --    NEW {0} -->       |
    |                             |  --    NEW {1} -->       |
    |                             |  --    NEW {2} -->       |
    | -- Update {1} -->           |                          |
    |                             |  -- UPDATE {1} -->       |
    | -- Update {2} -->           |                          |
                                 /* {2} unchanged - No update  */
    | -- Update {3} -->           |                          |
    |                             |  --    NEW {3} -->       |
 Remote disconnect - wait for reconnect
 ...
 Remote reconnected - determine missed updates
    |              <--Subscribe-- |                          |
    |-- Initial Data {0,1,3,4}--> |                          |
                                 /* {0} unchanged - No update  */
    |                             |  -- UPDATE {1} -->       |
    |                             |  -- DELETE {2} -->       |
                                 /* {3} unchanged - No update  */
    |                             |  --    NEW {4} -->       |
```